### PR TITLE
#184 #192 In json.c, forwarded serialize-base to serialize-value; extracted methods for primitive serialization

### DIFF
--- a/cx/include/cx_string.h
+++ b/cx/include/cx_string.h
@@ -24,8 +24,6 @@ char *chresc(char *out, char in, char delimiter);
  * Does not include surrounding double quotes.
  * The maximum number of characters to be printed is `n` including the null
  * character, but it may be less if the following character requires escaping.
- * The recommended length to allocate for the buffer can be obtained with
- * `stresclen`, adding 2 if you surrounding double quotes.
  * The resulting string is null terminated.
  */
 size_t stresc(char *out, size_t n, const char *in);

--- a/cx/src/cx_string.c
+++ b/cx/src/cx_string.c
@@ -147,7 +147,6 @@ size_t stresc(char *out, size_t n, const char *in) {
     const char *ptr = in;
     char ch, *bptr = out, buff[3];
     size_t written = 0;
-
     while ((ch = *ptr++)) {
         if ((written += (chresc(buff, ch, '"') - buff)) <= n) {
             *bptr++ = buff[0];
@@ -156,9 +155,9 @@ size_t stresc(char *out, size_t n, const char *in) {
             }
         }
     }
-
-    if (bptr) *bptr = '\0';
-
+    if (bptr) {
+        *bptr = '\0';
+    }
     return written;
 }
 

--- a/generator/html/src/html.c
+++ b/generator/html/src/html.c
@@ -252,7 +252,7 @@ error:
 
 
 cx_int16 cortex_genMain(cx_generator g) {
-    const char docs_filename[] = "docs";
+    const char docs_filename[] = "doc";
     int success;
 
     cx_mkdir(docs_filename);


### PR DESCRIPTION
Before, serialize-base was calling serialize members instead of serialize-value. This also helps make the code slightly more concise by letting serialize-composite handle the addition of curly braces.

Because serialization of primitives was handled in the same method all together, the code was not very readable and was difficult to maintain. Now, serialize-primitive will forward to one of several new static methods for each primitive kind.