### PR TITLE
Allow explicit nil in libmap to omit library

### DIFF
--- a/build/libmapping.rb
+++ b/build/libmapping.rb
@@ -27,15 +27,15 @@ module LibMapping
 
     @@libmap = {
         'Linux' =>   {'dl'=>'dl', 'm'=>'m', 'rt'=>'rt', 'xml2' => 'xml2'},
-        'Mac' =>     {'dl'=>'dl', 'm'=>'m', 'xml2' => 'xml2'},
+        'Mac' =>     {'dl'=>'dl', 'm'=>'m', 'xml2' => 'xml2', 'rt'=>nil},
         'Windows' => {}
     }
 
     def self.mapLibs(libs)
-        libs.select do |i|
-            @@libmap[Os.name][i]
-        end.map do |i|
-            @@libmap[Os.name][i]
+      libs.map do |i|
+        if @@libmap[Os.name].has_key?(i) then @@libmap[Os.name][i]
+        else i
         end
+      end.compact
     end
 end

--- a/cx/include/cx_async.h
+++ b/cx/include/cx_async.h
@@ -55,8 +55,7 @@ int cx_rwmutexUnlock(cx_rwmutex mutex);
 int cx_rwmutexFree(cx_rwmutex mutex);
 
 /* Semaphore */
-typedef struct cx_sem_s cx_sem_s;
-typedef cx_sem_s* cx_sem;
+typedef struct cx_sem_s* cx_sem;
 
 cx_sem cx_semNew(unsigned int initValue);
 int cx_semPost(cx_sem);

--- a/cx/include/cx_async_posix.h
+++ b/cx/include/cx_async_posix.h
@@ -10,7 +10,6 @@
 
 #include "pthread.h"
 #include "signal.h"
-#include "semaphore.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -40,6 +39,12 @@ typedef struct cx_mutex_s {
     char** l_symbols;
 #endif
 }cx_mutex_s;
+    
+typedef struct cx_sem_s {
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    int value;
+}cx_sem_s;
 
 #define CX_MUTEX_INITIALIZER {PTHREAD_MUTEX_INITIALIZER}
 #define CX_RWMUTEX_INITIALIZER {PTHREAD_RWLOCK_INITIALIZER}


### PR DESCRIPTION
__3rd party libs__
I think this solves the dual problems of omitting librt from mac builds and allowing packages like icecx to specify their own 3rd party libs.

__POSIX Semaphores on OS X__
Unnamed semaphores are [unsupported](http://heldercorreia.com/blog/semaphores-in-mac-os-x) in OS X.  I built emulation using pthread condition variables.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cortexlang/cortex/284)
<!-- Reviewable:end -->